### PR TITLE
fix SCn begin-end

### DIFF
--- a/author/part3/chapter_logic_productions.tex
+++ b/author/part3/chapter_logic_productions.tex
@@ -16,6 +16,7 @@
 
 \bigskip
 
+\begin{SCn}
 \begin{scnrelfromlist}{библиографическая ссылка}
 	\scnitem{\scncite{Golenkov1996_2}}
 	\scnitem{\scncite{Averin2004}}
@@ -34,12 +35,15 @@
 	\scnitem{\scncite{Rybakov2020}}
 	\scnitem{\scncite{Gavrilova2001}}
 \end{scnrelfromlist}
+\end{SCn}
 
 \bigskip
 
+\begin{SCn}
 \begin{scnrelfromlist}{подраздел}
 	\scnitem{\ref{logic_lang_os}~\nameref{logic_lang_os}}
 \end{scnrelfromlist}
+\end{SCn}
 
 \section{Операционная семантика логических языков, используемых ostis-системами}
 \label{logic_lang_os}


### PR DESCRIPTION
Обёрнута ли команда \abstract в SCn begin-end?